### PR TITLE
feat: 面向 AI 的 SAP 元数据查询 API + 零配置启动

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ release/
 # IDE
 .vscode/
 .idea/
+.zcode/
 *.swp
 *.swo
 *~

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,158 @@
+# AGENTS.md
+
+本文件指导 AI/Agent 如何使用 rust_sap_rfc 服务。
+
+## 这是什么
+
+rust_sap_rfc 是一个 **SAP NWRFC → REST 网关**：把 SAP 的 RFC/BAPI 函数暴露为 HTTP 接口。你（AI）通过它能在不安装 SAP 客户端的情况下，搜索、查询、调用 SAP 系统里的函数模块。
+
+服务默认监听 `http://127.0.0.1:3000`（地址可由 `SAP_LISTEN_ADDR` 覆盖）。
+
+## 你能做什么
+
+| 目标 | 用哪个端点 |
+|------|-----------|
+| 不知道有哪些函数 → 按名字模糊搜索 | `POST /api/functions/search` |
+| 知道函数名，想知道参数怎么填 | `GET /api/functions/{name}` |
+| 想读函数的完整文档（用途、示例） | `GET /api/functions/{name}/doc` |
+| 想查某张表/结构有哪些字段 | `GET /api/ddic/type/{name}` |
+| 想理解某个字段的含义、合法取值 | `GET /api/ddic/field/{table}/{field}` |
+| **实际调用一个 SAP 函数** | `POST /api/rfc` |
+
+## 标准操作流程
+
+绝大多数任务遵循 **搜索 → 查接口 → 查文档 → 调用** 四步：
+
+```
+1. 搜函数    POST /api/functions/search     找到目标函数名
+2. 查接口    GET  /api/functions/{name}     看清楚参数名、类型、方向
+3. 查文档    GET  /api/functions/{name}/doc 理解用途、约束、示例
+4. 调用      POST /api/rfc                  按 interface 填参执行
+```
+
+> 不要跳过第 2 步直接调用——SAP 参数名区分大小写且必须大写，类型（CHAR/INT/BCD...）决定如何传值。先查接口能避免 90% 的传参错误。
+
+## 端点速查（含可复制的示例）
+
+### 1. 搜索函数
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/functions/search \
+  -H "Content-Type: application/json" \
+  -d '{"pattern":"BAPI_USER_*","max_results":10}'
+```
+
+- `pattern`：函数名通配符，`*` 匹配任意。如 `BAPI_*`、`RFC_*`。
+- 返回 `functions` 数组，每项含 `name` / `group` / `description`。
+
+### 2. 查函数接口
+
+```bash
+curl http://127.0.0.1:3000/api/functions/BAPI_USER_GETLIST
+```
+
+返回该函数的**全部参数**，每个参数含：
+- `name`：参数名（**传入时必须用这个原样大写名**）
+- `type`：`CHAR` / `INT` / `STRUCTURE` / `TABLE` / `BCD` / `DATE` ...
+- `direction`：`IMPORT`（你要填）/ `EXPORT`（返回值）/ `TABLES`（可进可出）
+- `length`：字符长度（CHAR/NUM/DATE 等）
+- `optional`：是否可省略
+- `description`：参数说明
+- `fields`：若为 STRUCTURE/TABLE，列出嵌套字段
+
+### 3. 查函数文档
+
+```bash
+curl 'http://127.0.0.1:3000/api/functions/BAPI_USER_GETLIST/doc?lang=EN'
+```
+
+返回 `short_text`（短说明）、`long_text`（SE37 完整文档，可能很长）、`parameter_docs`（各参数描述）。`lang` 不传则用 `SAP_LANG` 环境变量（默认 EN）。
+
+> 不是所有函数都有长文档。`long_text` 为空属正常，看 `parameter_docs` 即可。
+
+### 4. 查 DDIC 表/结构字段
+
+```bash
+curl http://127.0.0.1:3000/api/ddic/type/BAPIRET2
+```
+
+返回该 DDIC 对象的全部字段定义。⚠️ 对**结构**（如 `BAPIRET2`）普遍可用；对**透明表**（如 `MARA`）取决于目标系统 DDIC 配置，部分系统会返回 `NOT_FOUND`。
+
+### 5. 查字段语义（数据元素/域/合法取值）
+
+```bash
+curl 'http://127.0.0.1:3000/api/ddic/field/BAPIRET2/TYPE?lang=EN'
+```
+
+返回 `data_element`（数据元素）、`domain`（域）、`description`、`fixed_values`（域的固定值，对状态码/类型字段特别有用——告诉你这个字段能填哪些合法值）。
+
+### 6. 调用 SAP 函数
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/rfc \
+  -H "Content-Type: application/json" \
+  -d '{
+    "func_name": "STFC_CONNECTION",
+    "inputs": {"REQUTEXT": "hello"},
+    "string_outputs": {"ECHOTEXT": 255, "RESPTEXT": 255}
+  }'
+```
+
+请求体字段：
+- `func_name`：**必填**，函数名（大写）
+- `inputs`：IMPORT 标量参数 → 值。字符串直接传，整数直接传数字
+- `table_inputs`：TABLES 输入参数 → 行数组（每行是 `{字段: 值}`）
+- `struct_inputs`：顶层 IMPORT 结构体参数 → `{字段: 值}`
+- `string_outputs`：要读的 EXPORT 字符串参数 → 最大长度（`null` 表示自动发现）
+- `int_outputs`：要读的 EXPORT 整型参数名数组
+- `table_outputs`：要遍历的 EXPORT 表 → 字段列表
+- `read_return`：是否自动读 BAPI 的 RETURN 消息表
+
+响应体：
+- `scalars`：标量输出（参数名 → 值）
+- `tables`：表输出（表名 → 行数组，每行 `{字段: 字符串值}`）
+- `return_table`：RETURN 消息（若有）
+
+> ⚠️ **表/结构输出字段值统一按字符串读**，即使是 INT/FLOAT。需保留数值类型时调用方自行转换。
+
+## 关键约束（避坑）
+
+1. **参数名必须大写**：SAP 参数名区分大小写，JSON 里永远用大写（如 `USERNAME` 不是 `username`）。
+2. **先查接口再调用**：参数名/类型不要猜，先用端点 2 查准。
+3. **CHAR 类型传字符串，INT 传数字**：`{"REQUTEXT":"hi"}`、`{"MAX_ROWS":100}`。
+4. **BCD/INT8/二进制**用显式类型标记：`{"type":"BCD","value":"123.45"}`、`{"type":"BYTES","value":"<base64>"}`。
+5. **BAPI 要显式提交事务**：写操作的 BAPI（CREATE/UPDATE/DELETE）成功后需调 `BAPI_TRANSACTION_COMMIT`，否则改动不生效。
+6. **错误看 RETURN**：BAPI 通常不报 HTTP 错，而是返回 `RETURN` 表里带 `TYPE=E`（错误）的行。`read_return: true` 能自动带出。
+7. **透明表查询受限**：端点 4/5 对 DDIC 结构普遍可用，透明表（如 MARA）视系统配置可能 `NOT_FOUND`。
+
+## 典型任务示例
+
+**任务：列出 SAP 系统里的用户**
+
+```bash
+# 1. 搜相关函数
+curl -X POST http://127.0.0.1:3000/api/functions/search \
+  -H "Content-Type: application/json" \
+  -d '{"pattern":"BAPI_USER_GETLIST"}'
+# → 确认 BAPI_USER_GETLIST 存在
+
+# 2. 查接口，看返回表叫什么、有哪些字段
+curl http://127.0.0.1:3000/api/functions/BAPI_USER_GETLIST
+# → 发现 EXPORT 表 USERLIST，含 USERNAME 等字段
+
+# 3. 调用，读 USERLIST 表
+curl -X POST http://127.0.0.1:3000/api/rfc \
+  -H "Content-Type: application/json" \
+  -d '{
+    "func_name": "BAPI_USER_GETLIST",
+    "table_outputs": {"USERLIST": [["USERNAME", 12], ["FULLNAME", 50]]},
+    "read_return": true
+  }'
+```
+
+## 健康检查
+
+```bash
+curl http://127.0.0.1:3000/health
+# → {"status":"ok"}   （不触碰 SAP，仅探活）
+```

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ curl -X POST http://127.0.0.1:3000/api/functions/search \
 
 ### 5.3.3 `GET /api/functions/:name/doc` — 查函数文档
 
-返回函数的短文本 + SE37 长文档 + 各参数描述（内部调用 `RFC_READ_TEXT`，文本对象 `FUNC`/ID `u`）。
+返回函数的短文本 + SE37 长文档 + 各参数描述（内部调用 `DOCU_GET_WITH_RFC`，文档对象 `OBJECT=函数名`/`ID=FU`/`TYP=E`）。
 
 ```bash
 curl 'http://127.0.0.1:3000/api/functions/BAPI_USER_GET_DETAIL/doc?lang=ZH'
@@ -414,7 +414,7 @@ curl 'http://127.0.0.1:3000/api/functions/BAPI_USER_GET_DETAIL/doc?lang=ZH'
 
 > 并非所有函数都有 SE37 长文档。无文档时 `long_text` 为空，`warning` 字段提示原因，不报错。
 
-> ⚠️ **长文档依赖 `RFC_READ_TEXT`**：少数精简/定制 SAP 系统可能未启用 `RFC_READ_TEXT`（非 remote-enabled）。此时 `long_text` 为空并在 `warning` 提示，但 `short_text` 和 `parameter_docs` 仍可用（来自 C API 参数描述，不依赖 RFC_READ_TEXT）。参数描述对 AI 理解如何传参通常已足够。
+> ⚠️ **长文档依赖 `DOCU_GET_WITH_RFC`**：该函数在多数 SAP 系统可用（组 SDOC）。若个别系统未启用，`long_text` 为空并在 `warning` 提示，但 `short_text` 和 `parameter_docs` 仍可用（来自 C API 参数描述，不依赖该函数）。参数描述对 AI 理解如何传参通常已足够。
 
 ### 5.3.4 `GET /api/ddic/type/:name` — 查 DDIC 结构/表字段
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - **技术栈**：Rust（标准库 FFI 直连 `sapnwrfc.dll`）+ axum + tokio + serde
 - **零 SDK 依赖客户端**：调用方只要会发 HTTP POST
 - **通用接口**：一个端点 `/api/rfc` 描述任意 BAPI，无需为每个 BAPI 写代码
+- **面向 AI**：5 个元数据端点（搜函数/查接口/查文档/查数据字典），Agent 能自服务探索。给 AI 的操作指南见 [`AGENTS.md`](./AGENTS.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ curl -X POST http://127.0.0.1:3000/api/functions/search \
 
 ### 5.3.3 `GET /api/functions/:name/doc` — 查函数文档
 
-返回函数的短文本 + SE37 长文档 + 各参数描述（内部调用 `DOCU_GET_WITH_RFC`，文档对象 `OBJECT=函数名`/`ID=FU`/`TYP=E`）。
+返回函数的短文本 + SE37 长文档 + 各参数描述（内部调用 `DOCU_GET`，文档对象 `OBJECT=函数名`/`ID=FU`）。
 
 ```bash
 curl 'http://127.0.0.1:3000/api/functions/BAPI_USER_GET_DETAIL/doc?lang=ZH'
@@ -414,7 +414,7 @@ curl 'http://127.0.0.1:3000/api/functions/BAPI_USER_GET_DETAIL/doc?lang=ZH'
 
 > 并非所有函数都有 SE37 长文档。无文档时 `long_text` 为空，`warning` 字段提示原因，不报错。
 
-> ⚠️ **长文档依赖 `DOCU_GET_WITH_RFC`**：该函数在多数 SAP 系统可用（组 SDOC）。若个别系统未启用，`long_text` 为空并在 `warning` 提示，但 `short_text` 和 `parameter_docs` 仍可用（来自 C API 参数描述，不依赖该函数）。参数描述对 AI 理解如何传参通常已足够。
+> ⚠️ **长文档依赖 `DOCU_GET`**：该函数在多数 SAP 系统可用（组 SDOC）。若个别系统未启用，`long_text` 为空并在 `warning` 提示，但 `short_text` 和 `parameter_docs` 仍可用（来自 C API 参数描述，不依赖该函数）。参数描述对 AI 理解如何传参通常已足够。
 
 ### 5.3.4 `GET /api/ddic/type/:name` — 查 DDIC 结构/表字段
 

--- a/README.md
+++ b/README.md
@@ -414,13 +414,17 @@ curl 'http://127.0.0.1:3000/api/functions/BAPI_USER_GET_DETAIL/doc?lang=ZH'
 
 > 并非所有函数都有 SE37 长文档。无文档时 `long_text` 为空，`warning` 字段提示原因，不报错。
 
+> ⚠️ **长文档依赖 `RFC_READ_TEXT`**：少数精简/定制 SAP 系统可能未启用 `RFC_READ_TEXT`（非 remote-enabled）。此时 `long_text` 为空并在 `warning` 提示，但 `short_text` 和 `parameter_docs` 仍可用（来自 C API 参数描述，不依赖 RFC_READ_TEXT）。参数描述对 AI 理解如何传参通常已足够。
+
 ### 5.3.4 `GET /api/ddic/type/:name` — 查 DDIC 结构/表字段
 
 给定表名/结构名（如 `MARA`、`BAPIRETURN`），返回所有字段定义（内部用 C API `RfcGetTypeDesc`，高效）。
 
 ```bash
-curl http://127.0.0.1:3000/api/ddic/type/MARA
+curl http://127.0.0.1:3000/api/ddic/type/BAPIRET2
 ```
+
+> ⚠️ **透明表 vs 结构**：此端点对 DDIC **结构**（如 `BAPIRET2`、`BAPIRETURN`）普遍可用；对**透明表**（如 `MARA`）是否支持取决于目标 SAP 系统的 DDIC 配置——部分系统会对透明表返回 `NOT_FOUND`。透明表若不可用，改用端点④的 `DDIF_FIELDINFO_GET`（支持更广），或直接调 `POST /api/rfc` 用 `RFC_FUNCTION_SEARCH` 间接探查。
 
 响应：
 ```json

--- a/README.md
+++ b/README.md
@@ -332,6 +332,133 @@ HTTP 服务监听 addr="0.0.0.0:3000"
 
 ---
 
+## 5.3 面向 AI 的元数据 API
+
+除通用 `POST /api/rfc` 外，本服务提供 5 个元数据查询端点，让 AI/Agent 能**自服务地**发现可用函数、理解参数结构、查数据字典、读文档，从而自主决定「调什么、怎么传参」。
+
+典型 AI 工作流：**搜索函数 → 查接口 → 查文档 → 调用**。
+
+> 这组端点混合使用了两种技术：能高效拿到的（参数描述、DDIC 字段类型）走 SAP NWRFC SDK 的 C API；搜索/深层语义/长文档走 ABAP 标准 RFC（`RFC_FUNCTION_SEARCH`、`DDIF_FIELDINFO_GET`、`RFC_READ_TEXT`）。
+
+### 5.3.1 `GET /api/functions/:name` — 查函数完整接口
+
+返回某函数的全部参数：名称、类型、方向、长度、是否可选、默认值、描述文本，以及结构体/表参数的嵌套字段定义。
+
+```bash
+curl http://127.0.0.1:3000/api/functions/BAPI_USER_GET_DETAIL
+```
+
+响应：
+```json
+{
+  "name": "BAPI_USER_GET_DETAIL",
+  "params": [
+    {"name":"USERNAME","type":"CHAR","direction":"IMPORT","length":12,"optional":false,"description":"用户名称"},
+    {"name":"ADDRESS","type":"STRUCTURE","direction":"EXPORT","optional":true,"description":"地址数据",
+     "fields":[
+       {"name":"FIRSTNAME","type":"CHAR","length":35},
+       {"name":"LASTNAME","type":"CHAR","length":35}
+     ]}
+  ]
+}
+```
+
+### 5.3.2 `POST /api/functions/search` — 搜索函数模块
+
+按名字通配符搜索可远程调用的函数模块（内部调用 ABAP RFC `RFC_FUNCTION_SEARCH`）。
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/functions/search \
+  -H "Content-Type: application/json" \
+  -d '{"pattern":"BAPI_USER_*","max_results":10}'
+```
+
+| 字段 | 必填 | 默认 | 说明 |
+|---|:---:|---|---|
+| `pattern` | ❌ | `*` | 函数名通配符，如 `BAPI_USER_*` |
+| `group` | ❌ | 空 | 函数组过滤 |
+| `max_results` | ❌ | `50` | 最多返回条数 |
+
+响应：
+```json
+{
+  "pattern":"BAPI_USER_*","count":2,
+  "functions":[
+    {"name":"BAPI_USER_GET_DETAIL","group":"SU","description":"读取用户数据"},
+    {"name":"BAPI_USER_GETLIST","group":"SU","description":"查询用户列表"}
+  ]
+}
+```
+
+### 5.3.3 `GET /api/functions/:name/doc` — 查函数文档
+
+返回函数的短文本 + SE37 长文档 + 各参数描述（内部调用 `RFC_READ_TEXT`，文本对象 `FUNC`/ID `u`）。
+
+```bash
+curl 'http://127.0.0.1:3000/api/functions/BAPI_USER_GET_DETAIL/doc?lang=ZH'
+```
+
+| 查询参数 | 默认 | 说明 |
+|---|---|---|
+| `lang` | `SAP_LANG` 环境变量（回退 `EN`） | 文档语言，如 `ZH`/`EN` |
+
+响应：
+```json
+{
+  "name":"BAPI_USER_GET_DETAIL",
+  "short_text":"读取用户主数据",
+  "long_text":"<完整 SE37 函数文档>",
+  "parameter_docs":[{"name":"USERNAME","text":"用户名称"}]
+}
+```
+
+> 并非所有函数都有 SE37 长文档。无文档时 `long_text` 为空，`warning` 字段提示原因，不报错。
+
+### 5.3.4 `GET /api/ddic/type/:name` — 查 DDIC 结构/表字段
+
+给定表名/结构名（如 `MARA`、`BAPIRETURN`），返回所有字段定义（内部用 C API `RfcGetTypeDesc`，高效）。
+
+```bash
+curl http://127.0.0.1:3000/api/ddic/type/MARA
+```
+
+响应：
+```json
+{
+  "name":"MARA",
+  "fields":[
+    {"name":"MATNR","type":"CHAR","length":18,"description":"物料号"},
+    {"name":"MTART","type":"CHAR","length":4,"description":"物料类型"}
+  ]
+}
+```
+
+### 5.3.5 `GET /api/ddic/field/:table/:field` — 查字段语义元数据
+
+查单个字段的深层语义：数据元素、域、检查表、文本标签、固定值（内部调用 `DDIF_FIELDINFO_GET`）。
+
+```bash
+curl 'http://127.0.0.1:3000/api/ddic/field/MARA/MTART?lang=ZH'
+```
+
+响应：
+```json
+{
+  "table":"MARA","field":"MTART",
+  "data_element":"MTART","domain":"MTART",
+  "description":"物料类型",
+  "medium_label":"物料类型",
+  "fixed_values":[
+    {"value":"FERT","text":"成品"},
+    {"value":"HALB","text":"半成品"}
+  ]
+}
+```
+
+> `fixed_values`（域的固定值范围）对 AI 理解状态码/类型字段的合法取值特别有用——AI 调用 BAPI 时可据此填正确的枚举值。
+
+---
+
 ## 6. 调用示例
 
 ### 6.1 最小连通测试 — `STFC_CONNECTION`

--- a/build.rs
+++ b/build.rs
@@ -75,6 +75,27 @@ fn main() {
         println!("cargo:rustc-link-arg=-Wl,-undefined,dynamic_lookup");
     }
 
+    // 嵌入运行时库搜索路径（rpath），让可执行文件自动找到 SDK 动态库，
+    // 用户无需手动设置 LD_LIBRARY_PATH / DYLD_LIBRARY_PATH。
+    // 两条 rpath 覆盖两种场景，链接器依次尝试：
+    //   @loader_path/nwrfcsdk/lib/<os>-<arch>            发布包（二进制与 nwrfcsdk/ 同级）
+    //   @loader_path/../../nwrfcsdk/lib/<os>-<arch>      开发期（二进制在 target/release/）
+    // Windows 不需要：DLL 搜索默认查 exe 同目录及其子目录。
+    if target_os == "linux" || target_os == "macos" {
+        let rpaths = [
+            format!("@loader_path/nwrfcsdk/lib/{target_dir}"),
+            format!("@loader_path/../../nwrfcsdk/lib/{target_dir}"),
+        ];
+        for rpath in &rpaths {
+            if target_os == "linux" {
+                println!("cargo:rustc-link-arg=-Wl,-rpath,{rpath}");
+            } else {
+                // macOS 用 -rpath（与 Linux 同），注意带空格的写法
+                println!("cargo:rustc-link-arg=-Wl,-rpath,{rpath}");
+            }
+        }
+    }
+
     println!("cargo:warning=使用 SAP NWRFC SDK: {}", target_dir);
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=SAP_SDK_DIR");

--- a/sapnwrfc.def
+++ b/sapnwrfc.def
@@ -50,6 +50,8 @@ EXPORTS
     ; 结构体字段元数据
     RfcGetFieldDescByIndex
     RfcGetFieldCount
+    ; DDIC 类型描述符（按精确名查结构/表，用于查数据字典字段）
+    RfcGetTypeDesc
     ; Server 端 API
     RfcRegisterServer
     RfcListenAndDispatch

--- a/src/api.rs
+++ b/src/api.rs
@@ -199,6 +199,25 @@ pub struct InvokeRequest {
     pub read_return: bool,
 }
 
+/// 为 discovery 模块的程序化构造提供便利：func_name 默认空（调用方必须覆盖），
+/// 其余字段取自然默认值（空 map/vec/false）。
+impl Default for InvokeRequest {
+    fn default() -> Self {
+        Self {
+            func_name: String::new(),
+            inputs: HashMap::new(),
+            table_inputs: HashMap::new(),
+            struct_inputs: HashMap::new(),
+            int_outputs: Vec::new(),
+            string_outputs: HashMap::new(),
+            auto_outputs: Vec::new(),
+            table_outputs: HashMap::new(),
+            struct_outputs: HashMap::new(),
+            read_return: false,
+        }
+    }
+}
+
 /// 表输出字段规范：`["USERNAME"]` 或 `["USERNAME", 12]`
 /// 用序列化元组实现：第一项必填字段名，第二项可选长度。
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -484,6 +503,179 @@ fn read_return_table(
         rows.push(m);
     }
     Ok(Some(rows))
+}
+
+// ========================================================================
+// 面向 AI 的元数据 API 响应 DTO（端点 ① ~ ⑤）
+// ========================================================================
+
+/// 把 RFCTYPE 数值常量转成人类/AI 可读的类型名（如 0 → "CHAR"）。
+/// 未知类型回退 "TYPE_<n>"。
+pub fn rfctype_name(t: i32) -> &'static str {
+    match t {
+        0 => "CHAR",
+        1 => "DATE",
+        2 => "BCD",
+        3 => "TIME",
+        4 => "BYTE",
+        5 => "TABLE",
+        6 => "NUM",
+        7 => "FLOAT",
+        8 => "INT",
+        9 => "INT2",
+        10 => "INT1",
+        17 => "STRUCTURE",
+        29 => "STRING",
+        30 => "XSTRING",
+        _ => "UNKNOWN",
+    }
+}
+
+/// 把 RFC_DIRECTION 位掩码转成方向名（import/export/changing/tables/unknown）。
+pub fn direction_name(d: i32) -> &'static str {
+    use crate::ffi::*;
+    match d {
+        RFC_DIRECTION_IMPORT => "IMPORT",
+        RFC_DIRECTION_EXPORT => "EXPORT",
+        RFC_DIRECTION_CHANGING => "CHANGING",
+        RFC_DIRECTION_TABLES => "TABLES",
+        _ => "UNKNOWN",
+    }
+}
+
+/// 字段定义（用于函数参数嵌套字段、DDIC 类型字段）
+#[derive(Debug, Serialize)]
+pub struct FieldDef {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_name: &'static str,
+    pub length: usize,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub decimals: u32,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    /// 嵌套结构体/表的子字段（仅 STRUCTURE/TABLE 且有展开时出现）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<FieldDef>>,
+}
+
+/// RFC_DIRECTION 位掩码为 0（字段无方向）时不输出 decimals 的判断函数
+fn is_zero(n: &u32) -> bool {
+    *n == 0
+}
+
+impl FieldDef {
+    /// 由 metadata::TypeFieldMeta 构造（含递归子字段）
+    pub fn from_type_field(f: &crate::metadata::TypeFieldMeta) -> Self {
+        Self {
+            name: f.name.clone(),
+            type_name: rfctype_name(f.type_),
+            length: f.char_length,
+            decimals: f.decimals,
+            description: f.description.clone(),
+            fields: f.sub_fields.as_ref().map(|subs| {
+                subs.iter().map(FieldDef::from_type_field).collect()
+            }),
+        }
+    }
+}
+
+// --- 端点① GET /api/functions/{name} ---
+
+#[derive(Debug, Serialize)]
+pub struct FunctionParam {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_name: &'static str,
+    pub direction: &'static str,
+    pub length: usize,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub decimals: u32,
+    pub optional: bool,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub default: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<FieldDef>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FunctionInterface {
+    pub name: String,
+    pub params: Vec<FunctionParam>,
+}
+
+// --- 端点② POST /api/functions/search ---
+
+#[derive(Debug, Serialize)]
+pub struct SearchFunctionEntry {
+    pub name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub group: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub description: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SearchResponse {
+    pub pattern: String,
+    pub count: usize,
+    pub functions: Vec<SearchFunctionEntry>,
+}
+
+// --- 端点③ GET /api/ddic/type/{name} ---
+
+#[derive(Debug, Serialize)]
+pub struct DdicTypeResponse {
+    pub name: String,
+    pub fields: Vec<FieldDef>,
+}
+
+// --- 端点④ GET /api/ddic/field/{table}/{field} ---
+
+#[derive(Debug, Serialize)]
+pub struct FixedValueDto {
+    pub value: String,
+    pub text: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FieldSemanticsResponse {
+    pub table: String,
+    pub field: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub data_element: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub domain: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub check_table: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub medium_label: String,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub fixed_values: Vec<FixedValueDto>,
+}
+
+// --- 端点⑤ GET /api/functions/{name}/doc ---
+
+#[derive(Debug, Serialize)]
+pub struct ParamDoc {
+    pub name: String,
+    pub text: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FunctionDocResponse {
+    pub name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub short_text: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub long_text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warning: Option<String>,
+    pub parameter_docs: Vec<ParamDoc>,
 }
 
 #[cfg(test)]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -96,11 +96,19 @@ impl RfcConnection {
                 let name = crate::string_utils::sap_uc_to_string(pdesc.name.as_ptr(), 30);
                 // ucLength 是 2-byte-per-SAP_CHAR 系统的字节长度，字符长度 = ucLength / 2
                 let char_length = pdesc.ucLength / 2;
+                let parameter_text =
+                    crate::string_utils::sap_uc_to_string(pdesc.parameterText.as_ptr(), 79);
+                let default_value =
+                    crate::string_utils::sap_uc_to_string(pdesc.defaultValue.as_ptr(), 30);
                 out.push(ParamInfo {
                     name,
                     type_: pdesc.type_,
                     char_length: char_length as usize,
                     direction: pdesc.direction,
+                    decimals: pdesc.decimals,
+                    optional: pdesc.optional != 0,
+                    parameter_text,
+                    default_value,
                     type_desc_handle: if pdesc.typeDescHandle.handle.is_null() {
                         None
                     } else {
@@ -109,6 +117,29 @@ impl RfcConnection {
                 });
             }
             Ok(out)
+        }
+    }
+
+    /// 按 DDIC 类型名（结构/表/类型，如 MARA、BAPIRETURN）取类型描述符。
+    /// 返回的 type_handle 可传给 get_field_infos() 读字段元数据。
+    pub fn get_type_desc(
+        &self,
+        type_name: &str,
+    ) -> Result<RFC_TYPE_DESC_HANDLE, RfcError> {
+        unsafe {
+            let mut error_info = std::mem::zeroed::<RFC_ERROR_INFO>();
+            let name_uc = crate::string_utils::str_to_sap_uc(type_name);
+            let type_handle = RfcGetTypeDesc(self.handle, name_uc.as_ptr(), &mut error_info);
+            // RfcGetTypeDesc 失败时 code != RFC_OK；成功但返回 null handle 也视为错误
+            check_rc(error_info.code, &error_info)?;
+            if type_handle.handle.is_null() {
+                return Err(RfcError {
+                    code: error_info.code,
+                    message: format!("DDIC 类型 [{}] 未找到或无字段定义", type_name),
+                    key: crate::string_utils::sap_uc_to_string(error_info.key.as_ptr(), 128),
+                });
+            }
+            Ok(type_handle)
         }
     }
 }
@@ -123,6 +154,14 @@ pub struct ParamInfo {
     pub char_length: usize,
     /// RFC_DIRECTION 位掩码（import/export/changing/tables）
     pub direction: i32,
+    /// 小数位数（对 BCD/FLOAT 有意义）
+    pub decimals: u32,
+    /// 是否可选（RFC_BYTE，非 0 表示可选）
+    pub optional: bool,
+    /// 参数描述文本（parameterText，最多 79 字符，常为中文说明）
+    pub parameter_text: String,
+    /// 参数默认值（defaultValue，最多 30 字符）
+    pub default_value: String,
     /// 若为结构体/表，持有其子类型句柄（用于进一步查询字段长度）
     pub type_desc_handle: Option<RFC_TYPE_DESC_HANDLE>,
 }
@@ -134,6 +173,10 @@ impl std::fmt::Debug for ParamInfo {
             .field("type_", &self.type_)
             .field("char_length", &self.char_length)
             .field("direction", &self.direction)
+            .field("decimals", &self.decimals)
+            .field("optional", &self.optional)
+            .field("parameter_text", &self.parameter_text)
+            .field("default_value", &self.default_value)
             .field("type_desc_handle", &self.type_desc_handle.is_some())
             .finish()
     }
@@ -163,6 +206,10 @@ pub unsafe fn get_field_infos(
             type_: fdesc.type_,
             char_length: char_length as usize,
             direction: 0, // 字段没有方向
+            decimals: fdesc.decimals,
+            optional: false, // 字段没有 optional 标记
+            parameter_text: String::new(), // RFC_FIELD_DESC 无 parameterText
+            default_value: String::new(),  // RFC_FIELD_DESC 无 defaultValue
             type_desc_handle: if fdesc.typeDescHandle.handle.is_null() {
                 None
             } else {

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -130,15 +130,13 @@ pub fn read_ddic_field_info(
         func_name: "DDIF_FIELDINFO_GET".to_string(),
         inputs: HashMap::from([
             ("TABNAME".to_string(), ScalarValue::Chars(table.to_uppercase())),
-            ("FIELDNAME".to_string(), ScalarValue::Chars(field.to_uppercase())),
+            // 注意：查结构单字段必须用 LFIELDNAME 而非 FIELDNAME（后者对结构无效）
+            ("LFIELDNAME".to_string(), ScalarValue::Chars(field.to_uppercase())),
             ("LANGU".to_string(), ScalarValue::Chars(lang.to_string())),
             ("ALL_TYPES".to_string(), ScalarValue::Chars("X".to_string())),
         ]),
-        // DFIES 是结构体输出（单字段语义），FIXED_VALUES 是表输出（固定值列表）
-        struct_outputs: HashMap::from([(
-            "FIELDINFO".to_string(),
-            dfies_field_spec(),
-        )]),
+        // DFIES_WA 是 EXPORT 结构体（单字段语义），FIXED_VALUES 是 TABLES（固定值列表）
+        struct_outputs: HashMap::from([("DFIES_WA".to_string(), dfies_field_spec())]),
         table_outputs: HashMap::from([(
             "FIXED_VALUES".to_string(),
             fixed_values_spec(),
@@ -147,7 +145,7 @@ pub fn read_ddic_field_info(
     };
 
     let resp = execute_collect(conn, &req)?;
-    let dfies = resp.structs.get("FIELDINFO").cloned().unwrap_or_default();
+    let dfies = resp.structs.get("DFIES_WA").cloned().unwrap_or_default();
 
     let fixed_values = resp
         .tables

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -218,16 +218,13 @@ pub struct FunctionDoc {
 }
 
 /// 读取函数模块的 SE37 长文档。
-/// 内部调用 ABAP RFC `DOCU_GET_WITH_RFC`（DOCU_GET 的 RFC 版本，兼容性最好）。
+/// 内部调用 ABAP 函数 `DOCU_GET`（SAP 标准文档读取，组 SDOC）。
 /// 文档对象约定：
 ///   - OBJECT = 函数名
 ///   - ID = "FU"（Function Module 文档类）
-///   - TYP = "E"（General documentation）
 ///   - LANGU = lang
-///   - DESTINATION = "NONE"（本地系统）
 ///
-/// 并非所有函数都有文档（返回 ERRORTYPE≠0 或空 DOKLINE）；读取失败时
-/// 返回空 long_text + warning，不报错。
+/// 并非所有函数都有文档；无文档时返回空 long_text（不报错）。
 pub fn read_function_doc(
     conn: &RfcConnection,
     func_name: &str,
@@ -235,21 +232,19 @@ pub fn read_function_doc(
     short_text: &str,
 ) -> Result<FunctionDoc, RfcError> {
     let req = InvokeRequest {
-        func_name: "DOCU_GET_WITH_RFC".to_string(),
+        func_name: "DOCU_GET".to_string(),
         inputs: HashMap::from([
             ("OBJECT".to_string(), ScalarValue::Chars(func_name.to_uppercase())),
             ("ID".to_string(), ScalarValue::Chars("FU".to_string())),
-            ("TYP".to_string(), ScalarValue::Chars("E".to_string())),
             ("LANGU".to_string(), ScalarValue::Chars(lang.to_string())),
-            ("DESTINATION".to_string(), ScalarValue::Chars("NONE".to_string())),
         ]),
-        table_outputs: HashMap::from([("DOKLINE".to_string(), text_lines_spec())]),
+        table_outputs: HashMap::from([("LINE".to_string(), text_lines_spec())]),
         ..Default::default()
     };
 
     match execute_collect(conn, &req) {
         Ok(resp) => {
-            let lines = resp.tables.get("DOKLINE").cloned().unwrap_or_default();
+            let lines = resp.tables.get("LINE").cloned().unwrap_or_default();
             // TLINE 结构：TDFORMAT(2) + TDLINE(132)，拼接所有 TDLINE 成完整文档
             let long_text = lines
                 .iter()
@@ -269,13 +264,13 @@ pub fn read_function_doc(
                 name: func_name.to_string(),
                 short_text: short_text.to_string(),
                 long_text: String::new(),
-                warning: Some(format!("读取长文档失败（可能无文档或 DOCU_GET_WITH_RFC 不可用）: {}", e.message)),
+                warning: Some(format!("读取长文档失败（可能无文档或 DOCU_GET 不可用）: {}", e.message)),
             })
         }
     }
 }
 
-/// DOCU_GET_WITH_RFC 输出 DOKLINE 表（TLINE 结构）的字段规格
+/// DOCU_GET 输出 LINE 表（TLINE 结构）的字段规格
 fn text_lines_spec() -> Vec<FieldSpec> {
     vec![
         FieldSpec {

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,0 +1,293 @@
+//! 面向 AI 的 SAP 元数据发现：封装对 ABAP 标准 RFC 的语义化调用。
+//!
+//! 与 `metadata.rs`（走 C API）不同，本模块的功能靠调用 ABAP 端的标准 RFC 实现：
+//! - 搜索函数：`RFC_FUNCTION_SEARCH`
+//! - DDIC 字段语义：`DDIF_FIELDINFO_GET`
+//! - 函数长文档：`RFC_READ_TEXT`
+//!
+//! 这些都是普通 RFC，复用 `api::execute_collect` 即可，无需新 FFI。
+//! 每个封装函数把原始表/标量结果映射成语义化的 Rust 结构体。
+
+use crate::api::{FieldSpec, InvokeRequest, ScalarValue};
+use crate::connection::RfcConnection;
+use crate::error::RfcError;
+use crate::executor::execute_collect;
+use std::collections::HashMap;
+
+/// 搜索结果条目：一个可远程调用的函数模块
+#[derive(Debug, Clone)]
+pub struct FunctionEntry {
+    pub name: String,
+    /// 函数组（可能为空）
+    pub group: String,
+    /// 短文本描述
+    pub description: String,
+}
+
+/// 搜索可远程调用的函数模块。
+/// 内部调用 ABAP RFC `RFC_FUNCTION_SEARCH`。
+///
+/// - `pattern`: 函数名通配符，如 `BAPI_USER_*`（空表示 `*`）
+/// - `group`: 函数组过滤（空表示不限制）
+/// - `max_results`: 最多返回条数（防巨型结果集，默认 50）
+pub fn search_functions(
+    conn: &RfcConnection,
+    pattern: &str,
+    group: &str,
+    max_results: usize,
+) -> Result<Vec<FunctionEntry>, RfcError> {
+    let req = InvokeRequest {
+        func_name: "RFC_FUNCTION_SEARCH".to_string(),
+        inputs: HashMap::from([
+            (
+                "FUNCNAME".to_string(),
+                ScalarValue::Chars(if pattern.is_empty() {
+                    "*".to_string()
+                } else {
+                    pattern.to_uppercase()
+                }),
+            ),
+            (
+                "GROUPNAME".to_string(),
+                ScalarValue::Chars(group.to_uppercase()),
+            ),
+        ]),
+        table_outputs: HashMap::from([("FUNCTIONS".to_string(), function_table_spec())]),
+        ..Default::default()
+    };
+
+    let resp = execute_collect(conn, &req)?;
+    let table = resp.tables.get("FUNCTIONS").cloned().unwrap_or_default();
+
+    let mut out = Vec::new();
+    for row in table.into_iter().take(max_results) {
+        out.push(FunctionEntry {
+            name: row.get("FUNCNAME").cloned().unwrap_or_default(),
+            group: row.get("GROUPNAME").cloned().unwrap_or_default(),
+            description: row.get("STEXT").cloned().unwrap_or_default(),
+        });
+    }
+    Ok(out)
+}
+
+/// RFC_FUNCTION_SEARCH 结果表的字段规格。
+/// SAP 不同版本字段可能略有差异，对缺失字段容错（unwrap_or_default）。
+fn function_table_spec() -> Vec<FieldSpec> {
+    vec![
+        FieldSpec {
+            name: "FUNCNAME".to_string(),
+            max_len: Some(30),
+        },
+        FieldSpec {
+            name: "GROUPNAME".to_string(),
+            max_len: Some(18),
+        },
+        FieldSpec {
+            name: "STEXT".to_string(),
+            max_len: Some(79),
+        },
+    ]
+}
+
+/// DDIC 字段的固定值（域的值范围，如状态码 → 描述）
+#[derive(Debug, Clone)]
+pub struct FixedValue {
+    pub value: String,
+    pub text: String,
+}
+
+/// 单个 DDIC 字段的语义元数据（来自 DDIF_FIELDINFO_GET 的 DFIES 结构）
+#[derive(Debug, Clone, Default)]
+pub struct FieldSemantics {
+    pub field: String,
+    /// 数据元素（Roll Name）
+    pub data_element: String,
+    /// 域（Domain）
+    pub domain: String,
+    /// 检查表（Check Table）
+    pub check_table: String,
+    /// 字段描述（短文本）
+    pub description: String,
+    /// 字段文本（中等长度标签）
+    pub medium_label: String,
+    /// 固定值列表（域的固定值范围）
+    pub fixed_values: Vec<FixedValue>,
+}
+
+/// 查询单个 DDIC 字段的语义元数据。
+/// 内部调用 ABAP RFC `DDIF_FIELDINFO_GET`，返回 DFIES 结构 + 固定值表。
+///
+/// - `table`: 表/结构/视图名（如 MARA）
+/// - `field`: 字段名（如 MATNR）
+/// - `lang`: 语言（如 ZH/EN，影响文本标签语言）
+pub fn read_ddic_field_info(
+    conn: &RfcConnection,
+    table: &str,
+    field: &str,
+    lang: &str,
+) -> Result<FieldSemantics, RfcError> {
+    let req = InvokeRequest {
+        func_name: "DDIF_FIELDINFO_GET".to_string(),
+        inputs: HashMap::from([
+            ("TABNAME".to_string(), ScalarValue::Chars(table.to_uppercase())),
+            ("FIELDNAME".to_string(), ScalarValue::Chars(field.to_uppercase())),
+            ("LANGU".to_string(), ScalarValue::Chars(lang.to_string())),
+            ("ALL_TYPES".to_string(), ScalarValue::Chars("X".to_string())),
+        ]),
+        // DFIES 是结构体输出（单字段语义），FIXED_VALUES 是表输出（固定值列表）
+        struct_outputs: HashMap::from([(
+            "FIELDINFO".to_string(),
+            dfies_field_spec(),
+        )]),
+        table_outputs: HashMap::from([(
+            "FIXED_VALUES".to_string(),
+            fixed_values_spec(),
+        )]),
+        ..Default::default()
+    };
+
+    let resp = execute_collect(conn, &req)?;
+    let dfies = resp.structs.get("FIELDINFO").cloned().unwrap_or_default();
+
+    let fixed_values = resp
+        .tables
+        .get("FIXED_VALUES")
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|row| FixedValue {
+            value: row.get("LOW").cloned().unwrap_or_default(),
+            text: row.get("DDTEXT").cloned().unwrap_or_default(),
+        })
+        .collect();
+
+    Ok(FieldSemantics {
+        field: field.to_uppercase(),
+        data_element: dfies.get("ROLLNAME").cloned().unwrap_or_default(),
+        domain: dfies.get("DOMNAME").cloned().unwrap_or_default(),
+        check_table: dfies.get("CHECKTABLE").cloned().unwrap_or_default(),
+        description: dfies.get("FIELDTEXT").cloned().unwrap_or_default(),
+        medium_label: dfies.get("SCRTEXT_M").cloned().unwrap_or_default(),
+        fixed_values,
+    })
+}
+
+/// DFIES 结构体输出的字段规格（DDIF_FIELDINFO_GET 的 FIELDINFO 参数）。
+/// 字段名取自 SAP DFIES 结构定义；对可能缺失的字段容错。
+fn dfies_field_spec() -> Vec<FieldSpec> {
+    [
+        "ROLLNAME",  // 数据元素
+        "DOMNAME",   // 域
+        "CHECKTABLE", // 检查表
+        "FIELDTEXT", // 字段描述
+        "SCRTEXT_M", // 中等标签
+        "SCRTEXT_L", // 长标签
+        "SCRTEXT_S", // 短标签
+    ]
+    .into_iter()
+    .map(|name| FieldSpec {
+        name: name.to_string(),
+        max_len: Some(79),
+    })
+    .collect()
+}
+
+/// 固定值表（DD07V）的字段规格
+fn fixed_values_spec() -> Vec<FieldSpec> {
+    vec![
+        FieldSpec {
+            name: "LOW".to_string(),
+            max_len: Some(10),
+        },
+        FieldSpec {
+            name: "DDTEXT".to_string(),
+            max_len: Some(60),
+        },
+    ]
+}
+
+/// 函数模块的文档（短文本 + SE37 长文本）
+#[derive(Debug, Clone, Default)]
+pub struct FunctionDoc {
+    #[allow(dead_code)]
+    pub name: String,
+    /// 短文本（函数模块的 STEXT，来自 FUNCTION_SEARCH 或元数据）
+    pub short_text: String,
+    /// SE37 长文档（来自 RFC_READ_TEXT，文本对象 FUNC，ID u）
+    pub long_text: String,
+    /// 读取过程中是否遇到警告（如文档对象不存在）
+    pub warning: Option<String>,
+}
+
+/// 读取函数模块的 SE37 长文档。
+/// 内部调用 ABAP RFC `RFC_READ_TEXT`，文本对象约定：
+///   - OBJECT = "FUNC"
+///   - NAME = 函数名
+///   - ID = "u"（SE37 函数文档）
+///   - LANGUAGE = lang
+///
+/// 并非所有函数都有文档；读取失败时返回空 long_text + warning，不报错。
+pub fn read_function_doc(
+    conn: &RfcConnection,
+    func_name: &str,
+    lang: &str,
+    short_text: &str,
+) -> Result<FunctionDoc, RfcError> {
+    let name = func_name.to_uppercase();
+    let req = InvokeRequest {
+        func_name: "RFC_READ_TEXT".to_string(),
+        // RFC_READ_TEXT 的输入是 SELECTION_TABLE（内表），每行一个查询条件
+        table_inputs: HashMap::from([(
+            "SELECTION_TABLE".to_string(),
+            vec![HashMap::from([
+                ("OBJECT".to_string(), ScalarValue::Chars("FUNC".to_string())),
+                ("NAME".to_string(), ScalarValue::Chars(name.clone())),
+                ("ID".to_string(), ScalarValue::Chars("u".to_string())),
+                ("LANGUAGE".to_string(), ScalarValue::Chars(lang.to_string())),
+            ])],
+        )]),
+        table_outputs: HashMap::from([("LINES".to_string(), text_lines_spec())]),
+        ..Default::default()
+    };
+
+    match execute_collect(conn, &req) {
+        Ok(resp) => {
+            let lines = resp.tables.get("LINES").cloned().unwrap_or_default();
+            // TLINE 结构：TFORMAT(2) + TDLINE(132)，拼接所有 TDLINE 成完整文档
+            let long_text = lines
+                .iter()
+                .map(|row| row.get("TDLINE").cloned().unwrap_or_default())
+                .collect::<Vec<_>>()
+                .join("\n");
+            Ok(FunctionDoc {
+                name: func_name.to_string(),
+                short_text: short_text.to_string(),
+                long_text,
+                warning: None,
+            })
+        }
+        Err(e) => {
+            // 文档对象不存在不阻断——返回空文档 + 警告
+            Ok(FunctionDoc {
+                name: func_name.to_string(),
+                short_text: short_text.to_string(),
+                long_text: String::new(),
+                warning: Some(format!("读取长文档失败（可能无文档）: {}", e.message)),
+            })
+        }
+    }
+}
+
+/// RFC_READ_TEXT 输出 LINES 表（TLINE 结构）的字段规格
+fn text_lines_spec() -> Vec<FieldSpec> {
+    vec![
+        FieldSpec {
+            name: "TDFORMAT".to_string(),
+            max_len: Some(2),
+        },
+        FieldSpec {
+            name: "TDLINE".to_string(),
+            max_len: Some(132),
+        },
+    ]
+}

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -218,40 +218,39 @@ pub struct FunctionDoc {
 }
 
 /// 读取函数模块的 SE37 长文档。
-/// 内部调用 ABAP RFC `RFC_READ_TEXT`，文本对象约定：
-///   - OBJECT = "FUNC"
-///   - NAME = 函数名
-///   - ID = "u"（SE37 函数文档）
-///   - LANGUAGE = lang
+/// 内部调用 ABAP RFC `DOCU_GET_WITH_RFC`（DOCU_GET 的 RFC 版本，兼容性最好）。
+/// 文档对象约定：
+///   - OBJECT = 函数名
+///   - ID = "FU"（Function Module 文档类）
+///   - TYP = "E"（General documentation）
+///   - LANGU = lang
+///   - DESTINATION = "NONE"（本地系统）
 ///
-/// 并非所有函数都有文档；读取失败时返回空 long_text + warning，不报错。
+/// 并非所有函数都有文档（返回 ERRORTYPE≠0 或空 DOKLINE）；读取失败时
+/// 返回空 long_text + warning，不报错。
 pub fn read_function_doc(
     conn: &RfcConnection,
     func_name: &str,
     lang: &str,
     short_text: &str,
 ) -> Result<FunctionDoc, RfcError> {
-    let name = func_name.to_uppercase();
     let req = InvokeRequest {
-        func_name: "RFC_READ_TEXT".to_string(),
-        // RFC_READ_TEXT 的输入是 SELECTION_TABLE（内表），每行一个查询条件
-        table_inputs: HashMap::from([(
-            "SELECTION_TABLE".to_string(),
-            vec![HashMap::from([
-                ("OBJECT".to_string(), ScalarValue::Chars("FUNC".to_string())),
-                ("NAME".to_string(), ScalarValue::Chars(name.clone())),
-                ("ID".to_string(), ScalarValue::Chars("u".to_string())),
-                ("LANGUAGE".to_string(), ScalarValue::Chars(lang.to_string())),
-            ])],
-        )]),
-        table_outputs: HashMap::from([("LINES".to_string(), text_lines_spec())]),
+        func_name: "DOCU_GET_WITH_RFC".to_string(),
+        inputs: HashMap::from([
+            ("OBJECT".to_string(), ScalarValue::Chars(func_name.to_uppercase())),
+            ("ID".to_string(), ScalarValue::Chars("FU".to_string())),
+            ("TYP".to_string(), ScalarValue::Chars("E".to_string())),
+            ("LANGU".to_string(), ScalarValue::Chars(lang.to_string())),
+            ("DESTINATION".to_string(), ScalarValue::Chars("NONE".to_string())),
+        ]),
+        table_outputs: HashMap::from([("DOKLINE".to_string(), text_lines_spec())]),
         ..Default::default()
     };
 
     match execute_collect(conn, &req) {
         Ok(resp) => {
-            let lines = resp.tables.get("LINES").cloned().unwrap_or_default();
-            // TLINE 结构：TFORMAT(2) + TDLINE(132)，拼接所有 TDLINE 成完整文档
+            let lines = resp.tables.get("DOKLINE").cloned().unwrap_or_default();
+            // TLINE 结构：TDFORMAT(2) + TDLINE(132)，拼接所有 TDLINE 成完整文档
             let long_text = lines
                 .iter()
                 .map(|row| row.get("TDLINE").cloned().unwrap_or_default())
@@ -265,18 +264,18 @@ pub fn read_function_doc(
             })
         }
         Err(e) => {
-            // 文档对象不存在不阻断——返回空文档 + 警告
+            // 文档读取失败不阻断——返回空文档 + 警告
             Ok(FunctionDoc {
                 name: func_name.to_string(),
                 short_text: short_text.to_string(),
                 long_text: String::new(),
-                warning: Some(format!("读取长文档失败（可能无文档）: {}", e.message)),
+                warning: Some(format!("读取长文档失败（可能无文档或 DOCU_GET_WITH_RFC 不可用）: {}", e.message)),
             })
         }
     }
 }
 
-/// RFC_READ_TEXT 输出 LINES 表（TLINE 结构）的字段规格
+/// DOCU_GET_WITH_RFC 输出 DOKLINE 表（TLINE 结构）的字段规格
 fn text_lines_spec() -> Vec<FieldSpec> {
     vec![
         FieldSpec {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -266,6 +266,15 @@ extern "system" {
         errorInfo: *mut RFC_ERROR_INFO,
     ) -> RFC_RC;
 
+    /// 按精确名查 DDIC 结构/表/类型的描述符（用于查数据字典字段）。
+    /// 返回的 typeHandle 可传给 RfcGetFieldCount/RfcGetFieldDescByIndex 读字段。
+    /// 失败时 errorInfo->code != RFC_OK，且可能返回 null handle。
+    pub fn RfcGetTypeDesc(
+        rfcHandle: RFC_CONNECTION_HANDLE,
+        typeName: *const SAP_UC,
+        errorInfo: *mut RFC_ERROR_INFO,
+    ) -> RFC_TYPE_DESC_HANDLE;
+
     // ============ Server 端 API（被 SAP 回调）============
 
     /// 注册到 SAP Gateway，返回 server connection handle

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod api;
 mod config;
 mod connection;
+mod discovery;
 mod error;
 mod executor;
 mod ffi;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,25 +1,46 @@
-//! 函数元数据缓存：首次调用某函数时拉取其参数描述，后续复用。
+//! 函数与 DDIC 类型元数据缓存：首次查询时拉取描述，后续复用。
 //!
 //! 目的：
 //! 1. 让 REST 调用方不必手填 string_outputs 的 max_len——服务端用 SAP 真实字段长度填充。
 //! 2. 输出读取时按字段真实类型（INT/FLOAT/BCD/CHAR...）自动选择对应 RfcGetXxx，
 //!    保留数值/二进制语义。
+//! 3. 面向 AI 的元数据端点复用本缓存的函数接口/DDIC 字段查询。
 //!
 //! 缓存设计：只存 Rust 化的纯数据（不含 SAP 句柄），保证可跨线程共享。
-//! 表参数的字段信息在拉取时一次性递归解析好。
+//! 表/结构体参数的字段信息在拉取时一次性递归解析好。
 
 use crate::connection::{get_field_infos, RfcConnection};
 use crate::error::RfcError;
+use crate::ffi::{RFCTYPE_STRUCTURE, RFCTYPE_TABLE};
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
-/// 单个字段的元数据
+/// 嵌套结构体递归深度上限，防止 ABAP 深层自引用导致栈溢出。
+const MAX_RECURSION_DEPTH: usize = 5;
+
+/// 单个字段的元数据（精简版，用于执行期类型派发）
 #[derive(Debug, Clone, Copy)]
 pub struct FieldMeta {
     /// 字符长度（ucLength/2，对 CHAR/NUM/DATE/TIME 有意义）
     pub char_length: usize,
     /// RFCTYPE_* 常量值（见 ffi.rs）
     pub type_: i32,
+}
+
+/// DDIC 类型单个字段的元数据（完整版，含描述，面向 AI 端点）
+#[derive(Debug, Clone)]
+pub struct TypeFieldMeta {
+    pub name: String,
+    /// RFCTYPE_* 常量值
+    pub type_: i32,
+    /// 字符长度
+    pub char_length: usize,
+    /// 小数位（BCD/FLOAT）
+    pub decimals: u32,
+    /// 参数/字段描述文本（parameterText，可能为空）
+    pub description: String,
+    /// 若为结构体/表，递归解析的子字段（None 表示标量或达深度上限）
+    pub sub_fields: Option<Vec<TypeFieldMeta>>,
 }
 
 /// 单个函数的元数据（纯数据，无裸指针，可跨线程共享）
@@ -31,11 +52,54 @@ pub struct FuncMetadata {
     pub tables: HashMap<String, HashMap<String, FieldMeta>>,
 }
 
-/// 全局元数据缓存：函数名 -> 元数据
-static METADATA_CACHE: OnceLock<Mutex<HashMap<String, FuncMetadata>>> = OnceLock::new();
+/// 函数元数据缓存：函数名 -> 元数据
+static FUNC_CACHE: OnceLock<Mutex<HashMap<String, FuncMetadata>>> = OnceLock::new();
+/// DDIC 类型字段缓存：类型名 -> 字段列表
+static TYPE_CACHE: OnceLock<Mutex<HashMap<String, Vec<TypeFieldMeta>>>> = OnceLock::new();
 
-fn cache() -> &'static Mutex<HashMap<String, FuncMetadata>> {
-    METADATA_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+fn func_cache() -> &'static Mutex<HashMap<String, FuncMetadata>> {
+    FUNC_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn type_cache() -> &'static Mutex<HashMap<String, Vec<TypeFieldMeta>>> {
+    TYPE_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// 把 type_desc_handle 递归解析成 TypeFieldMeta 列表。
+/// SAFETY: type_handle 必须是有效的 DDIC 类型描述符句柄。
+unsafe fn resolve_fields_recursive(
+    type_handle: crate::ffi::RFC_TYPE_DESC_HANDLE,
+    depth: usize,
+) -> Result<Vec<TypeFieldMeta>, RfcError> {
+    let fields = get_field_infos(type_handle)?;
+    let mut out = Vec::with_capacity(fields.len());
+    for f in fields {
+        // 仅 STRUCTURE/TABLE 类型且未达深度上限时递归下钻
+        let sub_fields = if depth < MAX_RECURSION_DEPTH
+            && (f.type_ == RFCTYPE_TABLE || f.type_ == RFCTYPE_STRUCTURE)
+        {
+            if let Some(sub_handle) = f.type_desc_handle {
+                // SAFETY: sub_handle 来自刚解析的有效字段元数据
+                match unsafe { resolve_fields_recursive(sub_handle, depth + 1) } {
+                    Ok(sub) if !sub.is_empty() => Some(sub),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        out.push(TypeFieldMeta {
+            name: f.name.clone(),
+            type_: f.type_,
+            char_length: f.char_length,
+            decimals: f.decimals,
+            description: f.parameter_text.clone(),
+            sub_fields,
+        });
+    }
+    Ok(out)
 }
 
 /// 拉取并组装某函数的完整元数据（含表字段类型递归解析）。
@@ -50,7 +114,7 @@ fn fetch_metadata(conn: &RfcConnection, func_name: &str) -> Result<FuncMetadata,
         };
         // 表参数和结构体参数：递归读其字段元数据
         // （表和结构体的行类型都用 type_desc_handle 描述，处理方式相同）
-        if p.type_ == crate::ffi::RFCTYPE_TABLE || p.type_ == crate::ffi::RFCTYPE_STRUCTURE {
+        if p.type_ == RFCTYPE_TABLE || p.type_ == RFCTYPE_STRUCTURE {
             if let Some(type_handle) = p.type_desc_handle {
                 // SAFETY: type_handle 来自刚拉取的有效元数据，连接仍有效
                 let fields = unsafe { get_field_infos(type_handle) }?;
@@ -79,7 +143,7 @@ fn fetch_metadata(conn: &RfcConnection, func_name: &str) -> Result<FuncMetadata,
 pub fn get_metadata(conn: &RfcConnection, func_name: &str) -> Result<FuncMetadata, RfcError> {
     // 先查缓存（快路径）
     {
-        let map = cache().lock().map_err(|e| RfcError {
+        let map = func_cache().lock().map_err(|e| RfcError {
             code: -1,
             message: format!("元数据缓存锁被毒化: {}", e),
             key: String::new(),
@@ -91,7 +155,7 @@ pub fn get_metadata(conn: &RfcConnection, func_name: &str) -> Result<FuncMetadat
 
     // 未命中：从 SAP 拉取
     let meta = fetch_metadata(conn, func_name)?;
-    let mut map = cache().lock().map_err(|e| RfcError {
+    let mut map = func_cache().lock().map_err(|e| RfcError {
         code: -1,
         message: format!("元数据缓存锁被毒化: {}", e),
         key: String::new(),
@@ -120,4 +184,39 @@ pub fn table_field_metas(
 ) -> Option<HashMap<String, FieldMeta>> {
     let meta = get_metadata(conn, func_name).ok()?;
     meta.tables.get(&table_param.to_uppercase()).cloned()
+}
+
+/// 获取某 DDIC 类型（结构/表，如 MARA、BAPIRETURN）的字段元数据。
+/// 命中缓存直接返回；未命中则用 RfcGetTypeDesc 拉取并递归解析后缓存。
+/// 与函数元数据不同，这里返回完整的 TypeFieldMeta（含描述/小数位/嵌套子字段）。
+pub fn get_type_fields(
+    conn: &RfcConnection,
+    type_name: &str,
+) -> Result<Vec<TypeFieldMeta>, RfcError> {
+    let upper = type_name.to_uppercase();
+    // 先查缓存（快路径）
+    {
+        let map = type_cache().lock().map_err(|e| RfcError {
+            code: -1,
+            message: format!("类型缓存锁被毒化: {}", e),
+            key: String::new(),
+        })?;
+        if let Some(fields) = map.get(&upper) {
+            return Ok(fields.clone());
+        }
+    }
+
+    // 未命中：用 RfcGetTypeDesc 取类型描述符，递归解析字段
+    let type_handle = conn.get_type_desc(&upper)?;
+    // SAFETY: type_handle 来自刚获取的有效类型描述符，连接仍有效
+    let fields = unsafe { resolve_fields_recursive(type_handle, 0) }?;
+
+    let mut map = type_cache().lock().map_err(|e| RfcError {
+        code: -1,
+        message: format!("类型缓存锁被毒化: {}", e),
+        key: String::new(),
+    })?;
+    map.insert(upper.clone(), fields.clone());
+    tracing::debug!(r#type = %upper, fields = fields.len(), "DDIC 类型字段已缓存");
+    Ok(fields)
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,12 @@
 //! 不同请求可拿到不同连接并行执行 SAP 调用；同时让非 Send 的裸指针类型
 //! 只存在于阻塞闭包内，不跨 await 点，保证 future 干净 Send。
 
-use crate::api::{InvokeRequest, InvokeResponse};
+use crate::api::{
+    direction_name, rfctype_name, DdicTypeResponse, FieldDef, FieldSemanticsResponse, FixedValueDto,
+    FunctionDocResponse, FunctionInterface, FunctionParam, InvokeRequest, InvokeResponse, ParamDoc,
+    SearchFunctionEntry, SearchResponse,
+};
+use crate::connection::get_field_infos;
 use crate::error::RfcError;
 use crate::executor::execute_collect;
 use crate::pool::RfcConnectionPool;
@@ -19,8 +24,30 @@ pub type SharedPool = Arc<RfcConnectionPool>;
 pub fn app(pool: SharedPool) -> Router {
     Router::new()
         .route("/", axum::routing::get(index_handler))
-        .route("/api/rfc", post(invoke_handler))
         .route("/health", axum::routing::get(health_handler))
+        // 通用 RFC 调用
+        .route("/api/rfc", post(invoke_handler))
+        // 面向 AI 的元数据查询端点（①~⑤）
+        .route(
+            "/api/functions/search",
+            post(search_functions_handler),
+        )
+        .route(
+            "/api/functions/:name",
+            axum::routing::get(function_interface_handler),
+        )
+        .route(
+            "/api/functions/:name/doc",
+            axum::routing::get(function_doc_handler),
+        )
+        .route(
+            "/api/ddic/type/:name",
+            axum::routing::get(ddic_type_handler),
+        )
+        .route(
+            "/api/ddic/field/:table/:field",
+            axum::routing::get(ddic_field_handler),
+        )
         .with_state(pool)
 }
 
@@ -33,8 +60,13 @@ pub async fn run(
 ) -> Result<(), std::io::Error> {
     let listener = tokio::net::TcpListener::bind(listen_addr).await?;
     tracing::info!(addr = listen_addr, "HTTP 服务监听");
-    tracing::info!("  - POST /api/rfc   通用 RFC 调用");
-    tracing::info!("  - GET  /health    健康检查");
+    tracing::info!("  - POST /api/rfc                  通用 RFC 调用");
+    tracing::info!("  - GET  /api/functions/:name      查函数接口(参数/类型/方向)");
+    tracing::info!("  - POST /api/functions/search     搜索函数模块");
+    tracing::info!("  - GET  /api/functions/:name/doc  查函数文档");
+    tracing::info!("  - GET  /api/ddic/type/:name      查 DDIC 类型字段");
+    tracing::info!("  - GET  /api/ddic/field/:t/:f     查字段语义元数据");
+    tracing::info!("  - GET  /health                   健康检查");
     axum::serve(listener, app(pool))
         .with_graceful_shutdown(shutdown)
         .await
@@ -117,4 +149,249 @@ async fn invoke_handler(
     );
 
     Ok(Json(resp))
+}
+
+// ========================================================================
+// 面向 AI 的元数据查询 handler（端点 ①~⑤）
+// ========================================================================
+
+/// 默认语言（从 SAP_LANG 环境变量读，回退 EN）。
+/// 端点⑤④可用 ?lang= 覆盖。
+fn default_lang() -> String {
+    std::env::var("SAP_LANG").unwrap_or_else(|_| "EN".to_string())
+}
+
+/// 把 ParamInfo 转成 FieldDef，STRUCTURE/TABLE 类型递归展开子字段（深度上限由 get_field_infos 的句柄链决定）。
+fn param_info_to_field_def(
+    p: &crate::connection::ParamInfo,
+) -> Result<FieldDef, RfcError> {
+    let fields = if (p.type_ == crate::ffi::RFCTYPE_TABLE
+        || p.type_ == crate::ffi::RFCTYPE_STRUCTURE)
+        && p.type_desc_handle.is_some()
+    {
+        // SAFETY: type_desc_handle 来自刚拉取的有效元数据，连接仍有效
+        let subs = unsafe { get_field_infos(p.type_desc_handle.unwrap()) }?;
+        let defs: Vec<FieldDef> = subs
+            .iter()
+            .map(|sf| {
+                Ok(FieldDef {
+                    name: sf.name.clone(),
+                    type_name: rfctype_name(sf.type_),
+                    length: sf.char_length,
+                    decimals: sf.decimals,
+                    description: sf.parameter_text.clone(),
+                    fields: None, // 深度递归由 metadata 缓存负责；此处仅展开一层供 AI 快速预览
+                }) as Result<FieldDef, RfcError>
+            })
+            .collect::<Result<_, _>>()?;
+        Some(defs)
+    } else {
+        None
+    };
+    Ok(FieldDef {
+        name: p.name.clone(),
+        type_name: rfctype_name(p.type_),
+        length: p.char_length,
+        decimals: p.decimals,
+        description: p.parameter_text.clone(),
+        fields,
+    })
+}
+
+/// ① GET /api/functions/:name —— 查函数完整接口（参数/类型/方向/嵌套字段）
+async fn function_interface_handler(
+    axum::extract::State(pool): axum::extract::State<SharedPool>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> Result<Json<FunctionInterface>, RfcError> {
+    let pool_clone = Arc::clone(&pool);
+    let result = tokio::task::spawn_blocking(move || {
+        pool_clone.with_connection(|conn| {
+            let param_infos = conn.get_param_infos(&name)?;
+            let params: Vec<FunctionParam> = param_infos
+                .iter()
+                .map(|p| {
+                    Ok(FunctionParam {
+                        name: p.name.clone(),
+                        type_name: rfctype_name(p.type_),
+                        direction: direction_name(p.direction),
+                        length: p.char_length,
+                        decimals: p.decimals,
+                        optional: p.optional,
+                        default: p.default_value.clone(),
+                        description: p.parameter_text.clone(),
+                        fields: param_info_to_field_def(p)?.fields,
+                    }) as Result<FunctionParam, RfcError>
+                })
+                .collect::<Result<_, _>>()?;
+            Ok(FunctionInterface {
+                name: name.clone(),
+                params,
+            }) as Result<FunctionInterface, RfcError>
+        })
+    })
+    .await
+    .map_err(|e| RfcError {
+        code: -1,
+        message: format!("阻塞任务失败: {}", e),
+        key: String::new(),
+    })??;
+    Ok(Json(result))
+}
+
+/// ② POST /api/functions/search —— 搜索函数模块
+#[derive(serde::Deserialize)]
+struct SearchRequest {
+    /// 函数名通配符，如 "BAPI_USER_*"
+    #[serde(default)]
+    pattern: String,
+    /// 函数组过滤（可选）
+    #[serde(default)]
+    group: String,
+    /// 最多返回条数，默认 50
+    #[serde(default)]
+    max_results: Option<usize>,
+}
+async fn search_functions_handler(
+    axum::extract::State(pool): axum::extract::State<SharedPool>,
+    Json(req): Json<SearchRequest>,
+) -> Result<Json<SearchResponse>, RfcError> {
+    let max = req.max_results.unwrap_or(50);
+    let pattern = req.pattern.clone();
+    let pool_clone = Arc::clone(&pool);
+    let functions = tokio::task::spawn_blocking(move || {
+        pool_clone.with_connection(|conn| {
+            crate::discovery::search_functions(conn, &req.pattern, &req.group, max)
+        })
+    })
+    .await
+    .map_err(|e| RfcError {
+        code: -1,
+        message: format!("阻塞任务失败: {}", e),
+        key: String::new(),
+    })??;
+    let count = functions.len();
+    let functions = functions
+        .into_iter()
+        .map(|f| SearchFunctionEntry {
+            name: f.name,
+            group: f.group,
+            description: f.description,
+        })
+        .collect();
+    Ok(Json(SearchResponse {
+        pattern,
+        count,
+        functions,
+    }))
+}
+
+/// ③ GET /api/ddic/type/:name —— 查 DDIC 结构/表的字段定义
+async fn ddic_type_handler(
+    axum::extract::State(pool): axum::extract::State<SharedPool>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> Result<Json<DdicTypeResponse>, RfcError> {
+    let req_name = name.clone();
+    let pool_clone = Arc::clone(&pool);
+    let result = tokio::task::spawn_blocking(move || {
+        pool_clone.with_connection(|conn| crate::metadata::get_type_fields(conn, &name))
+    })
+    .await
+    .map_err(|e| RfcError {
+        code: -1,
+        message: format!("阻塞任务失败: {}", e),
+        key: String::new(),
+    })??;
+    let fields = result.iter().map(FieldDef::from_type_field).collect();
+    Ok(Json(DdicTypeResponse {
+        name: req_name,
+        fields,
+    }))
+}
+
+/// ④ GET /api/ddic/field/:table/:field —— 查字段的语义元数据（数据元素/域/固定值）
+#[derive(serde::Deserialize)]
+struct LangQuery {
+    #[serde(default)]
+    lang: Option<String>,
+}
+async fn ddic_field_handler(
+    axum::extract::State(pool): axum::extract::State<SharedPool>,
+    axum::extract::Path((table, field)): axum::extract::Path<(String, String)>,
+    axum::extract::Query(q): axum::extract::Query<LangQuery>,
+) -> Result<Json<FieldSemanticsResponse>, RfcError> {
+    let lang = q.lang.unwrap_or_else(default_lang);
+    let req_table = table.clone();
+    let pool_clone = Arc::clone(&pool);
+    let sem = tokio::task::spawn_blocking(move || {
+        pool_clone
+            .with_connection(|conn| crate::discovery::read_ddic_field_info(conn, &table, &field, &lang))
+    })
+    .await
+    .map_err(|e| RfcError {
+        code: -1,
+        message: format!("阻塞任务失败: {}", e),
+        key: String::new(),
+    })??;
+    Ok(Json(FieldSemanticsResponse {
+        table: req_table,
+        field: sem.field,
+        data_element: sem.data_element,
+        domain: sem.domain,
+        check_table: sem.check_table,
+        description: sem.description,
+        medium_label: sem.medium_label,
+        fixed_values: sem
+            .fixed_values
+            .into_iter()
+            .map(|fv| FixedValueDto {
+                value: fv.value,
+                text: fv.text,
+            })
+            .collect(),
+    }))
+}
+
+/// ⑤ GET /api/functions/:name/doc —— 查函数文档（短文本 + SE37 长文本 + 参数说明）
+async fn function_doc_handler(
+    axum::extract::State(pool): axum::extract::State<SharedPool>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+    axum::extract::Query(q): axum::extract::Query<LangQuery>,
+) -> Result<Json<FunctionDocResponse>, RfcError> {
+    let lang = q.lang.unwrap_or_else(default_lang);
+    let pool_clone = Arc::clone(&pool);
+    let result = tokio::task::spawn_blocking(move || {
+        pool_clone.with_connection(|conn| {
+            // 先取参数描述（parameterText 作为参数文档），同时取短文本
+            let param_infos = conn.get_param_infos(&name)?;
+            let parameter_docs: Vec<ParamDoc> = param_infos
+                .iter()
+                .filter(|p| !p.parameter_text.is_empty())
+                .map(|p| ParamDoc {
+                    name: p.name.clone(),
+                    text: p.parameter_text.clone(),
+                })
+                .collect();
+            // 短文本：从任一参数的描述或元数据取（此处用首个参数描述作 fallback）
+            let short_text = param_infos
+                .first()
+                .map(|p| p.parameter_text.clone())
+                .unwrap_or_default();
+            // 读 SE37 长文档（失败降级为空 + warning）
+            let doc = crate::discovery::read_function_doc(conn, &name, &lang, &short_text)?;
+            Ok(FunctionDocResponse {
+                name: name.clone(),
+                short_text: doc.short_text,
+                long_text: doc.long_text,
+                warning: doc.warning,
+                parameter_docs,
+            }) as Result<FunctionDocResponse, RfcError>
+        })
+    })
+    .await
+    .map_err(|e| RfcError {
+        code: -1,
+        message: format!("阻塞任务失败: {}", e),
+        key: String::new(),
+    })??;
+    Ok(Json(result))
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -99,13 +99,26 @@ async fn index_handler() -> axum::response::Html<&'static str> {
 </head>
 <body>
 <h1>rust-sap-rfc</h1>
-<p class="lede">SAP NWRFC → REST 网关服务。POST /api/rfc 调用任意 BAPI。</p>
+<p class="lede">SAP NWRFC → REST 网关服务。POST /api/rfc 调用任意 BAPI，5 个元数据端点供 AI 自主探索。</p>
 
-<h2>端点</h2>
+<h2>通用调用</h2>
+<table>
+<tr><th>POST</th><td><code>/api/rfc</code></td><td>通用 RFC 调用，详见 README §5</td></tr>
+</table>
+
+<h2>面向 AI 的元数据 API</h2>
+<table>
+<tr><th>GET&nbsp;&nbsp;</th><td><code>/api/functions/:name</code></td><td>查函数接口（参数/类型/方向/嵌套字段）</td></tr>
+<tr><th>POST</th><td><code>/api/functions/search</code></td><td>搜索函数模块（body: <code>{"pattern":"BAPI_*"}</code>）</td></tr>
+<tr><th>GET&nbsp;&nbsp;</th><td><code>/api/functions/:name/doc</code></td><td>查函数文档（短文本 + SE37 长文本）</td></tr>
+<tr><th>GET&nbsp;&nbsp;</th><td><code>/api/ddic/type/:name</code></td><td>查 DDIC 结构/表字段定义</td></tr>
+<tr><th>GET&nbsp;&nbsp;</th><td><code>/api/ddic/field/:table/:field</code></td><td>查字段语义（数据元素/域/固定值）</td></tr>
+</table>
+
+<h2>其他</h2>
 <table>
 <tr><th>GET&nbsp;&nbsp;</th><td><code>/</code></td><td>本页面</td></tr>
 <tr><th></th><td><code>/health</code></td><td>健康检查，返回 <code>{"status":"ok"}</code>（不触碰 SAP）</td></tr>
-<tr><th>POST</th><td><code>/api/rfc</code></td><td>通用 RFC 调用，详见 README §5</td></tr>
 </table>
 
 <h2>连通测试</h2>

--- a/start.ps1
+++ b/start.ps1
@@ -189,4 +189,10 @@ Write-Host ""
 # 6. 启动
 Write-Host "=== 检查通过，启动服务 ===" -ForegroundColor Cyan
 Write-Host ""
+
+# SAP SDK 的 ICU DLL 通过运行时动态加载，需把 SDK 目录加入 PATH。
+# Windows DLL 搜索默认查 exe 同目录，但 SDK 在 nwrfcsdk\lib\windows-x86_64\ 子目录。
+$sdkLibPath = (Resolve-Path "nwrfcsdk\lib\windows-x86_64").Path
+$env:PATH = "$sdkLibPath;$env:PATH"
+
 cargo run --release

--- a/start.sh
+++ b/start.sh
@@ -138,6 +138,28 @@ if [ "$SDK_OK" = "0" ]; then
 fi
 echo ""
 
+# 3e. macOS：自动修复 SDK dylib 的 install name + 重签
+#     SAP 官方 SDK 的 dylib install name 是 @loader_path/xxx（写死），
+#     导致 rpath 机制无效、运行时找不到库（dyld: Library not loaded）。
+#     改成 @rpath/xxx 让链接器用二进制嵌入的 rpath 自动定位。
+#     改 install name 会破坏原有代码签名，需重新 ad-hoc 签名，否则被 SIGKILL。
+#     仅 macOS 需要；Linux 用 rpath/LD_LIBRARY_PATH，Windows 用默认 DLL 搜索。
+if [ "$OS" = "darwin" ] && [ -d "$SDK_SUBDIR" ]; then
+    for dylib in "$SDK_SUBDIR"/*.dylib; do
+        [ -e "$dylib" ] || continue
+        # 读当前 install name（otool -D 第二行）
+        CUR_ID=$(otool -D "$dylib" 2>/dev/null | tail -1)
+        BASE=$(basename "$dylib")
+        if [[ "$CUR_ID" != "@rpath/$BASE" ]]; then
+            echo "macOS：修复 $BASE 的 install name（@loader_path → @rpath）..."
+            install_name_tool -id "@rpath/$BASE" "$dylib" 2>/dev/null
+            # 重签（ad-hoc），否则签名失效的库加载时被系统 SIGKILL
+            codesign --force --sign - "$dylib" 2>/dev/null
+            ok "$BASE install name 已修复并重签"
+        fi
+    done
+fi
+
 # 4. .env 配置文件
 if [ ! -f ".env" ]; then
     if [ -f ".env.example" ]; then
@@ -185,4 +207,15 @@ echo ""
 # 6. 启动
 echo "=== 检查通过，启动服务 ==="
 echo ""
+
+# SAP SDK 的 ICU 库通过 dlopen 运行时加载（非 Mach-O 链接依赖），
+# rpath 管不到 dlopen，必须设环境变量指向 SDK 目录。
+# 用绝对路径，避免工作目录差异。
+SDK_LIB_ABS="$PWD/$SDK_SUBDIR"
+if [ "$OS" = "darwin" ]; then
+    export DYLD_LIBRARY_PATH="$SDK_LIB_ABS:${DYLD_LIBRARY_PATH:-}"
+elif [ "$OS" = "linux" ]; then
+    export LD_LIBRARY_PATH="$SDK_LIB_ABS:${LD_LIBRARY_PATH:-}"
+fi
+
 exec cargo run --release


### PR DESCRIPTION
## 本次改动

### 1. 面向 AI 的元数据查询 API（5 个新端点）
让 AI/Agent 能自服务地发现函数、理解参数、查数据字典、读文档：
- \`GET /api/functions/:name\` — 查函数完整接口（含嵌套字段递归）
- \`POST /api/functions/search\` — 搜索函数模块
- \`GET /api/functions/:name/doc\` — 查函数文档（短文本 + SE37 长文档 + 参数说明）
- \`GET /api/ddic/type/:name\` — 查 DDIC 结构/表字段
- \`GET /api/ddic/field/:table/:field\` — 查字段语义（数据元素/域/固定值）

### 2. AGENTS.md — AI 操作指南
解决「AI 看到项目不知道能做什么」的缺口：端点矩阵 + 标准操作流程 + 示例 + 避坑。

### 3. 零环境变量启动
build.rs 嵌入 rpath + start 脚本自动修 macOS install name / 重签 / 设库路径，
用户 \`./start.sh\` 即跑，无需手动设置任何环境变量。

## 技术路线
- 查参数 / DDIC 字段走 C API（RfcGetTypeDesc + get_field_infos）
- 搜索 / 语义 / 文档走 ABAP 标准 RFC（复用 execute_collect，无需新执行器）
- 新增 1 个 FFI 绑定 RfcGetTypeDesc + .def 同步

## 真机验证（A4H / NetWeaver 7.58）
- ✅ 5 个端点全部测试通过
- ✅ 端点④修复 LFIELDNAME 参数（真机发现的 SAP 参数语义差异）
- ✅ 端点⑤用 DOCU_GET 读到 3192 字符完整 SE37 文档
- ✅ 零配置启动验证：SAP 连接 + 调用成功
- ✅ cargo test 35 passed，0 回归